### PR TITLE
Fix unstyled plugin: link bundled index.css

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -21,6 +21,9 @@ along with this package; If not, see <http://www.gnu.org/licenses/>.
     <meta charset="utf-8">
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="index.css">
+    <link href="../../static/branding.css" rel="stylesheet" />
+
 
 
     <script type="text/javascript" src="index.js"></script>


### PR DESCRIPTION
esbuild/SCSS emits `dist/index.css` (~1.6MB PatternFly + app styles) but `index.html` only linked the JS bundles, so the plugin rendered completely unstyled in Cockpit. This adds `<link rel="stylesheet" href="index.css">` plus the shared `branding.css`, matching `cockpit-gps`/`cockpit-aiscatcher` which already render styled. Verified: rebuilt bundle now links the CSS and loads it.