### PR TITLE
Use the AryaOS design kit instead of a local copy of the old palette

### DIFF
--- a/build.js
+++ b/build.js
@@ -108,6 +108,21 @@ const context = await esbuild.context({
                     const destAssets = path.join('dist', 'assets');
                     fs.mkdirSync(destAssets, { recursive: true });
                     fs.cpSync(srcAssets, destAssets, { recursive: true });
+
+                    // AryaOS design-kit webfonts. theme.scss references these
+                    // as url(./fonts/*.woff2) relative to the stylesheet, and
+                    // *.woff2 is in `external` above, so esbuild leaves those
+                    // URLs untouched. Without these files the palette still
+                    // applies and only the typography silently falls back to
+                    // system fonts -- easy to miss, and missed on first pass.
+                    const srcFonts = path.join(
+                        'node_modules', '@snstac', 'cockpit-shared', 'src', 'fonts'
+                    );
+                    if (fs.existsSync(srcFonts)) {
+                        const destFonts = path.join('dist', 'fonts');
+                        fs.mkdirSync(destFonts, { recursive: true });
+                        fs.cpSync(srcFonts, destFonts, { recursive: true });
+                    }
                 });
             }
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@patternfly/react-core": "6.1.0",
         "@patternfly/react-icons": "6.1.0",
         "@patternfly/react-styles": "6.3.1",
-        "@snstac/cockpit-shared": "github:snstac/cockpit-shared#v1.0.0",
+        "@snstac/cockpit-shared": "github:snstac/cockpit-shared#v1.3.0",
         "qrcode-generator": "1.4.4",
         "react": "18.3.1",
         "react-dom": "18.3.1"
@@ -1635,8 +1635,8 @@
       "license": "MIT"
     },
     "node_modules/@snstac/cockpit-shared": {
-      "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/snstac/cockpit-shared.git#908a95233ef03956916ffed4155db4390e8a895c",
+      "version": "1.3.0",
+      "resolved": "git+ssh://git@github.com/snstac/cockpit-shared.git#4b9a6993ad0ac5125fd66396320a8fdb56b5b41b",
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 16"

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@patternfly/react-core": "6.1.0",
     "@patternfly/react-icons": "6.1.0",
     "@patternfly/react-styles": "6.3.1",
-    "@snstac/cockpit-shared": "github:snstac/cockpit-shared#v1.0.0",
+    "@snstac/cockpit-shared": "github:snstac/cockpit-shared#v1.3.0",
     "qrcode-generator": "1.4.4",
     "react": "18.3.1",
     "react-dom": "18.3.1"

--- a/src/app.scss
+++ b/src/app.scss
@@ -1,5 +1,9 @@
 @use "page.scss";
 
+// The AryaOS design kit: palette, type and spacing for every cockpit-*
+// plugin. Everything below inherits from it rather than redefining it.
+@use "@snstac/cockpit-shared/src/theme.scss";
+
 /* Spacing between stacked expandable cards only — do not set overflow on the Card (breaks PF / scrolling). */
 .aiscot-expandable-card {
     margin-top: 1rem;
@@ -32,22 +36,6 @@
     background: var(--pf-t--global--background--color--primary--default, var(--pf-c-card--BackgroundColor, #fff));
 }
 
-/* GPSTAK-style AryaOS operations console polish. */
-:root {
-    color-scheme: dark;
-    --aos-bg: #071211;
-    --aos-panel: #122322;
-    --aos-panel-2: #172c2a;
-    --aos-ink: #edf7f4;
-    --aos-muted: #9bb2ad;
-    --aos-border: rgb(124 170 160 / 28%);
-    --aos-border-strong: rgb(124 170 160 / 40%);
-    --aos-accent: #35a58f;
-    --aos-accent-dark: #6ed4be;
-    --aos-accent-ink: #071211;
-    --aos-danger: #ff8a7a;
-    --aos-ok: #74d8a4;
-}
 
 * {
     box-sizing: border-box;


### PR DESCRIPTION
`app.scss` defined its own 16-line `:root` palette — teal `#35a58f` accent, `#74d8a4` ok, `#ff8a7a` danger — the pre-kit console theme.

`cockpit-shared` was already a dependency, but **pinned at v1.0.0 and used only for its TypeScript modules**, so the design system in `theme.scss` was never reaching this plugin at all. The local block wasn't merely redundant — it was the only palette.

- Dependency → **v1.3.0**, the first tag containing `theme.scss` (1.2.0 added it but was never tagged)
- Import the kit, delete the local override

**Verified in the built CSS, not assumed:** `--sns-accent`, `--sns-brand`, `#56b4e9` and `#e4610f` present; `#35a58f` appears **zero** times; every relative `url()` in the bundle resolves on disk.

### The font trap

`build.js` now copies the kit's webfonts into `dist/fonts`. `theme.scss` references them as `url(./fonts/*.woff2)` relative to the stylesheet, and `*.woff2` is in esbuild's `external`, so those URLs are emitted untouched.

Without the copy the CSS still loads and **the palette still applies — only the typography silently falls back to system fonts.** That is exactly what my first build did, and it took checking every `url()` against disk to notice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197da7dhvcPoHxYKamrYqyM