### PR TITLE
Adopt AryaOS design kit and restore page scrolling

### DIFF
--- a/build.js
+++ b/build.js
@@ -108,6 +108,21 @@ const context = await esbuild.context({
                     const destAssets = path.join('dist', 'assets');
                     fs.mkdirSync(destAssets, { recursive: true });
                     fs.cpSync(srcAssets, destAssets, { recursive: true });
+
+                    // AryaOS design-kit webfonts. theme.scss references these
+                    // as url(./fonts/*.woff2) relative to the stylesheet, and
+                    // *.woff2 is in `external` above, so esbuild leaves those
+                    // URLs untouched. Without these files the palette still
+                    // applies and only the typography silently falls back to
+                    // system fonts -- easy to miss, and missed on first pass.
+                    const srcFonts = path.join(
+                        'node_modules', '@snstac', 'cockpit-shared', 'src', 'fonts'
+                    );
+                    if (fs.existsSync(srcFonts)) {
+                        const destFonts = path.join('dist', 'fonts');
+                        fs.mkdirSync(destFonts, { recursive: true });
+                        fs.cpSync(srcFonts, destFonts, { recursive: true });
+                    }
                 });
             }
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@patternfly/react-core": "6.1.0",
         "@patternfly/react-icons": "6.1.0",
         "@patternfly/react-styles": "6.3.1",
-        "@snstac/cockpit-shared": "github:snstac/cockpit-shared#v1.3.0",
+        "@snstac/cockpit-shared": "github:snstac/cockpit-shared#v1.3.1",
         "qrcode-generator": "1.4.4",
         "react": "18.3.1",
         "react-dom": "18.3.1"
@@ -1635,8 +1635,8 @@
       "license": "MIT"
     },
     "node_modules/@snstac/cockpit-shared": {
-      "version": "1.3.0",
-      "resolved": "git+ssh://git@github.com/snstac/cockpit-shared.git#4b9a6993ad0ac5125fd66396320a8fdb56b5b41b",
+      "version": "1.3.1",
+      "resolved": "git+ssh://git@github.com/snstac/cockpit-shared.git#c883b6afc56993e28235890b07fc08400e47dfae",
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 16"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@patternfly/react-core": "6.1.0",
         "@patternfly/react-icons": "6.1.0",
         "@patternfly/react-styles": "6.3.1",
-        "@snstac/cockpit-shared": "github:snstac/cockpit-shared#v1.0.0",
+        "@snstac/cockpit-shared": "github:snstac/cockpit-shared#v1.3.0",
         "qrcode-generator": "1.4.4",
         "react": "18.3.1",
         "react-dom": "18.3.1"
@@ -1635,8 +1635,8 @@
       "license": "MIT"
     },
     "node_modules/@snstac/cockpit-shared": {
-      "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/snstac/cockpit-shared.git#908a95233ef03956916ffed4155db4390e8a895c",
+      "version": "1.3.0",
+      "resolved": "git+ssh://git@github.com/snstac/cockpit-shared.git#4b9a6993ad0ac5125fd66396320a8fdb56b5b41b",
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 16"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "watch": "ESBUILD_WATCH='true' ./build.js",
-    "build": "./build.js",
+    "build": "node ./build.js",
     "test": "vitest run",
     "test:watch": "vitest",
     "eslint": "eslint src/",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@patternfly/react-core": "6.1.0",
     "@patternfly/react-icons": "6.1.0",
     "@patternfly/react-styles": "6.3.1",
-    "@snstac/cockpit-shared": "github:snstac/cockpit-shared#v1.0.0",
+    "@snstac/cockpit-shared": "github:snstac/cockpit-shared#v1.3.0",
     "qrcode-generator": "1.4.4",
     "react": "18.3.1",
     "react-dom": "18.3.1"

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@patternfly/react-core": "6.1.0",
     "@patternfly/react-icons": "6.1.0",
     "@patternfly/react-styles": "6.3.1",
-    "@snstac/cockpit-shared": "github:snstac/cockpit-shared#v1.3.0",
+    "@snstac/cockpit-shared": "github:snstac/cockpit-shared#v1.3.1",
     "qrcode-generator": "1.4.4",
     "react": "18.3.1",
     "react-dom": "18.3.1"

--- a/src/app.scss
+++ b/src/app.scss
@@ -47,6 +47,12 @@ body,
     block-size: 100%;
 }
 
+// Cockpit fixes the document body in place; plain-root plugins must provide
+// their own viewport scroller or expanded cards are clipped below the frame.
+#app {
+    overflow-y: auto;
+}
+
 body {
     margin: 0;
     background:

--- a/src/app.scss
+++ b/src/app.scss
@@ -1,5 +1,9 @@
 @use "page.scss";
 
+// The AryaOS design kit: palette, type and spacing for every cockpit-*
+// plugin. Everything below inherits from it rather than redefining it.
+@use "@snstac/cockpit-shared/src/theme.scss";
+
 /* Spacing between stacked expandable cards only — do not set overflow on the Card (breaks PF / scrolling). */
 .aiscot-expandable-card {
     margin-top: 1rem;
@@ -32,22 +36,6 @@
     background: var(--pf-t--global--background--color--primary--default, var(--pf-c-card--BackgroundColor, #fff));
 }
 
-/* GPSTAK-style AryaOS operations console polish. */
-:root {
-    color-scheme: dark;
-    --aos-bg: #071211;
-    --aos-panel: #122322;
-    --aos-panel-2: #172c2a;
-    --aos-ink: #edf7f4;
-    --aos-muted: #9bb2ad;
-    --aos-border: rgb(124 170 160 / 28%);
-    --aos-border-strong: rgb(124 170 160 / 40%);
-    --aos-accent: #35a58f;
-    --aos-accent-dark: #6ed4be;
-    --aos-accent-ink: #071211;
-    --aos-danger: #ff8a7a;
-    --aos-ok: #74d8a4;
-}
 
 * {
     box-sizing: border-box;

--- a/src/layout.test.ts
+++ b/src/layout.test.ts
@@ -1,0 +1,16 @@
+import { fileURLToPath } from 'node:url';
+
+import { compile } from 'sass';
+import { describe, expect, test } from 'vitest';
+
+describe('Cockpit page layout', () => {
+    test('provides a viewport-height root scroller', () => {
+        const css = compile(fileURLToPath(new URL('./app.scss', import.meta.url)), {
+            loadPaths: ['pkg/lib', 'node_modules'],
+            quietDeps: true,
+        }).css;
+
+        expect(css).toMatch(/html,\s*body,\s*#app\s*{[^}]*block-size:\s*100%/s);
+        expect(css).toMatch(/#app\s*{[^}]*overflow-y:\s*auto/s);
+    });
+});

--- a/src/layout.test.ts
+++ b/src/layout.test.ts
@@ -1,11 +1,9 @@
-import { fileURLToPath } from 'node:url';
-
 import { compile } from 'sass';
 import { describe, expect, test } from 'vitest';
 
 describe('Cockpit page layout', () => {
     test('provides a viewport-height root scroller', () => {
-        const css = compile(fileURLToPath(new URL('./app.scss', import.meta.url)), {
+        const css = compile('src/app.scss', {
             loadPaths: ['pkg/lib', 'node_modules'],
             quietDeps: true,
         }).css;

--- a/test/check-application
+++ b/test/check-application
@@ -19,6 +19,12 @@ class TestApplication(testlib.MachineCase):
         b.wait_visible("[data-testid=aiscot-tls-card]")
         b.wait_visible("[data-testid=aiscot-config-card]")
 
+        b.set_layout("medium")
+        b.click("#aiscot-debug-expand")
+        b.wait_js_cond("document.querySelector('#app').scrollHeight > document.querySelector('#app').clientHeight")
+        b.eval_js("document.querySelector('#app').scrollTop = document.querySelector('#app').scrollHeight")
+        b.wait_js_cond("document.querySelector('#app').scrollTop > 0")
+
 
 if __name__ == '__main__':
     testlib.test_main()


### PR DESCRIPTION
## Summary
- consume the shared AryaOS design-kit palette and bundled fonts
- make the Cockpit root a viewport-height vertical scroller
- add a compiled-SCSS regression test for expanded-card scrolling
- use a checkout-mode-independent Node build command

## Validation
- unit tests
- ESLint
- Stylelint
- production bundle
- Debian package build